### PR TITLE
Reject invalid Shamir share inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -139981,8 +139981,19 @@ var jsbtc=function(A){var i={};function e(t){if(i[t])return i[t].exports;var I=i
             try {
 
 
-                let n = parseInt($("#share-threshold")[0].value);
-                let m = parseInt($("#share-total")[0].value);
+                let thresholdValue = $("#share-threshold")[0].value.trim();
+                let totalValue = $("#share-total")[0].value.trim();
+                if (!/^\d+$/.test(thresholdValue) || !/^\d+$/.test(totalValue)) {
+                    await run_task(type_text, "#calc-status", "Threshold and total shares must be whole numbers", "text-red");
+                    return;
+                }
+
+                let n = parseInt(thresholdValue, 10);
+                let m = parseInt(totalValue, 10);
+                if (n < 2) {
+                    await run_task(type_text, "#calc-status", "Minimum threshold is 2 shares", "text-red");
+                    return;
+                }
                 if (m > 15) {
                     await run_task(type_text, "#calc-status", "This tool limited to 15 total shares", "text-red");
                     return;


### PR DESCRIPTION
## Summary
- Reject non-decimal threshold/total input before generating Shamir shares.
- Parse validated inputs explicitly as base-10 integers.
- Enforce a minimum threshold of 2 so invalid values cannot reach `splitMnemonic`.

This implements a direct web-tool validation fix for the invalid-threshold behavior reported in #6 and bitaps-com/jsbtc#48. Credit for the original report remains with that reporter; this PR is the implementation patch.

## Verification
- `git diff --check`

Bounty payout address for accepted implementation work: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`